### PR TITLE
Add W3C KeyboardEvent.key values support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Unless you want absolute flexibility we highly recommend you to use one of the d
 
 ### `keyHandler` decorator
 
-The decorator will decorate the given component with a `keyCode` and `keyName`
+The decorator will decorate the given component with a `keyValue`, `keyCode` and `keyName`
 property.
 
 ```jsx
@@ -60,17 +60,19 @@ The prop types of the `keyHandler` decorator are:
 
 ```js
 type Props = {
+  keyValue: ?string,
   keyCode: ?number,
   keyEventName: ?string,
   keyName: ?string,
 }
 ```
 
+* `keyValue` can be any given [W3C keyboard key value](https://www.w3.org/TR/DOM-Level-3-Events-key/)
 * `keyCode` can be any given [keyboard code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
 * `keyEventName` will default to `'keyup'`
 * `keyName` can be any given character
 
-You should either pass a `keyCode` or a `keyName`, not both.
+You should either pass a `keyValue`, a `keyCode` or a `keyName`, not both.
 
 ### `keyToggleHandler` decorator
 
@@ -119,6 +121,7 @@ The prop types of the `KeyHandler` component are:
 
 ```js
 type Props = {
+  keyValue: ?string,
   keyCode: ?number,
   keyEventName: string,
   keyName: ?string,
@@ -126,12 +129,13 @@ type Props = {
 };
 ```
 
+* `keyValue` can be any given [W3C keyboard key value](https://www.w3.org/TR/DOM-Level-3-Events-key/)
 * `keyCode` can be any given [keyboard code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
 * `keyEventName` will default to `'keyup'`
 * `keyName` can be any given character
 * `onKeyHandle` is the function that is being called when key code is handled
 
-You should either pass a `keyCode` or a `keyName`, not both.
+You should either pass a `keyValue`, a `keyCode` or a `keyName`, not both.
 
 ### Form key handling
 

--- a/lib/components/key-handler.js
+++ b/lib/components/key-handler.js
@@ -5,13 +5,14 @@ import keyNames from 'keycodes';
 import {canUseDOM} from 'exenv';
 
 import {KEYUP} from '../constants';
-import {isInput} from '../utils';
+import {isInput, keyNameVals} from '../utils';
 
 /**
  * Types.
  */
 
 type Props = {
+  keyValue: ?string,
   keyCode: ?number,
   keyEventName: string,
   keyName: ?string,
@@ -56,9 +57,11 @@ export default class KeyHandler extends React.Component {
   }
 
   handleKey(event: KeyboardEvent): void {
-    const keyCode = this.props.keyCode || keyNames(this.props.keyName);
+    const composed = keyCode => keyNameVals(keyNames(keyCode));
+    const keyValue = this.props.keyValue || composed(this.props.keyCode) || keyNameVals(this.props.keyName);
+    const eventKeyValue = event.key || composed(event.keyCode);
 
-    if (event.keyCode !== keyCode) {
+    if (eventKeyValue.toLowerCase() !== keyValue.toLowerCase()) {
       return;
     }
 
@@ -79,12 +82,14 @@ export default class KeyHandler extends React.Component {
  */
 
 type DecoratorProps = {
+  keyValue: ?string,
   keyCode: ?number,
   keyName: ?string,
   keyEventName: ?string,
 }
 
 type State = {
+  keyValue: ?string,
   keyCode: ?number,
   keyName: ?string,
 };
@@ -93,10 +98,10 @@ type State = {
  * KeyHandler decorators.
  */
 
-export function keyHandler({keyCode, keyName, keyEventName}: DecoratorProps): Function {
+export function keyHandler({keyValue, keyCode, keyName, keyEventName}: DecoratorProps): Function {
   return (component) => {
     return class KeyHandleDecorator extends React.Component {
-      state: State = { keyCode: null, keyName: null };
+      state: State = { keyValue: null, keyCode: null, keyName: null };
 
       constructor(props: any) {
         super(props);
@@ -107,7 +112,7 @@ export function keyHandler({keyCode, keyName, keyEventName}: DecoratorProps): Fu
       render(): ReactElement {
         return (
           <div>
-            <KeyHandler keyCode={keyCode} keyEventName={keyEventName} keyName={keyName} onKeyHandle={this.handleKey} />
+            <KeyHandler keyValue={keyValue} keyCode={keyCode} keyEventName={keyEventName} keyName={keyName} onKeyHandle={this.handleKey} />
 
             {this.renderDecoratedComponent()}
           </div>
@@ -115,22 +120,22 @@ export function keyHandler({keyCode, keyName, keyEventName}: DecoratorProps): Fu
       }
 
       renderDecoratedComponent(): ReactElement {
-        const {keyCode, keyName} = this.state;
+        const {keyValue, keyCode, keyName} = this.state;
 
-        return React.createElement(component, { ...this.props, keyCode, keyName });
+        return React.createElement(component, { ...this.props, keyValue, keyCode, keyName });
       }
 
       handleKey(event: KeyboardEvent): void {
-        this.setState({ keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: keyNameVals(keyNames(event.code)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };
 }
 
-export function keyToggleHandler({keyCode, keyName, keyEventName}: DecoratorProps): Function {
+export function keyToggleHandler({keyValue, keyCode, keyName, keyEventName}: DecoratorProps): Function {
   return (component) => {
     return class KeyHandleDecorator extends React.Component {
-      state: State = { keyCode: null, keyName: null };
+      state: State = { keyValue: null, keyCode: null, keyName: null };
 
       constructor(props: any) {
         super(props);
@@ -141,7 +146,7 @@ export function keyToggleHandler({keyCode, keyName, keyEventName}: DecoratorProp
       render(): ReactElement {
         return (
           <div>
-            <KeyHandler keyCode={keyCode} keyEventName={keyEventName} keyName={keyName} onKeyHandle={this.handleToggleKey} />
+            <KeyHandler keyValue={keyValue} keyCode={keyCode} keyEventName={keyEventName} keyName={keyName} onKeyHandle={this.handleToggleKey} />
 
             {this.renderDecoratedComponent()}
           </div>
@@ -149,17 +154,21 @@ export function keyToggleHandler({keyCode, keyName, keyEventName}: DecoratorProp
       }
 
       renderDecoratedComponent(): ReactElement {
-        const {keyCode, keyName} = this.state;
+        const {keyValue, keyCode, keyName} = this.state;
 
-        return React.createElement(component, { ...this.props, keyCode, keyName });
+        return React.createElement(component, { ...this.props, keyValue, keyCode, keyName });
       }
 
       handleToggleKey(event: KeyboardEvent): void {
-        if (this.state.keyCode === event.keyCode) {
-          return this.setState({ keyCode: null, keyName: null });
+        const composed = keyCode => keyNameVals(keyNames(keyCode));
+        const keyValue = this.state.keyValue || composed(this.state.keyCode) || keyNameVals(this.state.keyName);
+        const eventKeyValue = event.key || composed(event.keyCode);
+
+        if (eventKeyValue.toLowerCase() !== keyValue.toLowerCase()) {
+          return this.setState({ keyValue: null, keyCode: null, keyName: null });
         }
 
-        this.setState({ keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: keyNameVals(keyNames(event.code)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };

--- a/lib/components/key-handler.js
+++ b/lib/components/key-handler.js
@@ -5,7 +5,7 @@ import keyNames from 'keycodes';
 import {canUseDOM} from 'exenv';
 
 import {KEYUP} from '../constants';
-import {isInput, keyNameVals} from '../utils';
+import {isInput, keyValues, matchesKeyboardEvent} from '../utils';
 
 /**
  * Types.
@@ -57,7 +57,7 @@ export default class KeyHandler extends React.Component {
   }
 
   handleKey(event: KeyboardEvent): void {
-    if (!checkKeyValues(event, this.props)) {
+    if (!matchesKeyboardEvent(event, this.props)) {
       return;
     }
 
@@ -122,7 +122,7 @@ export function keyHandler({keyValue, keyCode, keyName, keyEventName}: Decorator
       }
 
       handleKey(event: KeyboardEvent): void {
-        this.setState({ keyValue: event.key || keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: event.key || keyValues(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };
@@ -156,32 +156,14 @@ export function keyToggleHandler({keyValue, keyCode, keyName, keyEventName}: Dec
       }
 
       handleToggleKey(event: KeyboardEvent): void {
-        if (!checkKeyValues(event, this.state)) {
+        if (!matchesKeyboardEvent(event, this.state)) {
           return this.setState({ keyValue: null, keyCode: null, keyName: null });
         }
 
-        this.setState({ keyValue: event.key || keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: event.key || keyValues(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };
-}
-
-/**
- * Helpers
- */
-function valFromCode(keyCode: ?number): ?string {
-  if (!keyCode) {
-    return;
-  }
-
-  return keyNameVals(keyNames(keyCode));
-}
-
-function checkKeyValues(event: KeyboardEvent, obj: Props | State): boolean {
-  const keyValue = obj.keyValue || valFromCode(obj.keyCode) || keyNameVals(obj.keyName);
-  const eventKeyValue = event.key || valFromCode(event.keyCode);
-
-  return String(eventKeyValue).toLowerCase() === String(keyValue).toLowerCase();
 }
 
 export * from '../constants';

--- a/lib/components/key-handler.js
+++ b/lib/components/key-handler.js
@@ -57,15 +57,7 @@ export default class KeyHandler extends React.Component {
   }
 
   handleKey(event: KeyboardEvent): void {
-    const composed = keyCode => keyNameVals(keyNames(keyCode));
-    const keyValue = this.props.keyValue || composed(this.props.keyCode) || keyNameVals(this.props.keyName);
-    const eventKeyValue = event.key || composed(event.keyCode);
-
-    if (typeof eventKeyValue !== 'string' || typeof keyValue !== 'string') {
-      return;
-    }
-
-    if (eventKeyValue.toLowerCase() !== keyValue.toLowerCase()) {
+    if (!checkKeyValues(event, this.props)) {
       return;
     }
 
@@ -130,7 +122,7 @@ export function keyHandler({keyValue, keyCode, keyName, keyEventName}: Decorator
       }
 
       handleKey(event: KeyboardEvent): void {
-        this.setState({ keyValue: keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: event.key || keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };
@@ -164,18 +156,32 @@ export function keyToggleHandler({keyValue, keyCode, keyName, keyEventName}: Dec
       }
 
       handleToggleKey(event: KeyboardEvent): void {
-        const composed = keyCode => keyNameVals(keyNames(keyCode));
-        const keyValue = this.state.keyValue || composed(this.state.keyCode) || keyNameVals(this.state.keyName);
-        const eventKeyValue = event.key || composed(event.keyCode);
-
-        if (eventKeyValue.toLowerCase() !== keyValue.toLowerCase()) {
+        if (!checkKeyValues(event, this.state)) {
           return this.setState({ keyValue: null, keyCode: null, keyName: null });
         }
 
-        this.setState({ keyValue: keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: event.key || keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };
+}
+
+/**
+ * Helpers
+ */
+function valFromCode(keyCode: ?number): ?string {
+  if (!keyCode) {
+    return;
+  }
+
+  return keyNameVals(keyNames(keyCode));
+}
+
+function checkKeyValues(event: KeyboardEvent, obj: Props | State): boolean {
+  const keyValue = obj.keyValue || valFromCode(obj.keyCode) || keyNameVals(obj.keyName);
+  const eventKeyValue = event.key || valFromCode(event.keyCode);
+
+  return String(eventKeyValue).toLowerCase() === String(keyValue).toLowerCase();
 }
 
 export * from '../constants';

--- a/lib/components/key-handler.js
+++ b/lib/components/key-handler.js
@@ -61,6 +61,10 @@ export default class KeyHandler extends React.Component {
     const keyValue = this.props.keyValue || composed(this.props.keyCode) || keyNameVals(this.props.keyName);
     const eventKeyValue = event.key || composed(event.keyCode);
 
+    if (typeof eventKeyValue !== 'string' || typeof keyValue !== 'string') {
+      return;
+    }
+
     if (eventKeyValue.toLowerCase() !== keyValue.toLowerCase()) {
       return;
     }
@@ -126,7 +130,7 @@ export function keyHandler({keyValue, keyCode, keyName, keyEventName}: Decorator
       }
 
       handleKey(event: KeyboardEvent): void {
-        this.setState({ keyValue: keyNameVals(keyNames(event.code)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };
@@ -168,7 +172,7 @@ export function keyToggleHandler({keyValue, keyCode, keyName, keyEventName}: Dec
           return this.setState({ keyValue: null, keyCode: null, keyName: null });
         }
 
-        this.setState({ keyValue: keyNameVals(keyNames(event.code)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
+        this.setState({ keyValue: keyNameVals(keyNames(event.keyCode)), keyCode: event.keyCode, keyName: keyNames(event.keyCode) });
       }
     };
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,7 @@ export function isInput(element: HTMLElement): boolean {
 /**
  * Maps [keycodes](https://www.npmjs.com/package/keycodes) key names to KeyboardEvent.key values.
  */
-export function keyNameVals(keyName: string): string {
+export function keyNameVals(keyName: ?string): ?string {
   const cases = {
     left: 'ArrowLeft',
     up: 'ArrowUp',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,17 @@
 /* @flow */
 
+import keyNames from 'keycodes';
+
+/**
+ * Types.
+ */
+
+type Props = {
+  keyValue: ?string,
+  keyCode: ?number,
+  keyName: ?string
+};
+
 /**
  * Check if `given` element is an input or textarea form element.
  */
@@ -17,11 +29,7 @@ export function isInput(element: HTMLElement): boolean {
 /**
  * Maps [keycodes](https://www.npmjs.com/package/keycodes) key names to KeyboardEvent.key values.
  */
-export function keyNameVals(keyName: ?string): string {
-  if (!keyName) {
-    return 'Unidentified';
-  }
-
+export function keyValues(keyName: string): string {
   const cases = {
     left: 'ArrowLeft',
     up: 'ArrowUp',
@@ -30,4 +38,21 @@ export function keyNameVals(keyName: ?string): string {
   };
 
   return cases[keyName] || keyName;
+}
+
+/**
+ * Maps keyCodes to KeyboardEvent.key values.
+ */
+export function keyValueFromCode(keyCode: number): string {
+  return keyValues(keyNames(keyCode));
+}
+
+/**
+ * Matches a KeyboardEvent against a given Props type by all its possible values.
+ */
+export function matchesKeyboardEvent(event: KeyboardEvent, {keyValue, keyCode, keyName}: Props): boolean {
+  const keyVal = keyValue || (keyCode && keyValueFromCode(keyCode)) || (keyName && keyValues(keyName));
+  const eventKeyVal = event.key || keyValueFromCode(event.keyCode);
+
+  return String(eventKeyVal).toLowerCase() === String(keyVal).toLowerCase();
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,11 @@ export function isInput(element: HTMLElement): boolean {
 /**
  * Maps [keycodes](https://www.npmjs.com/package/keycodes) key names to KeyboardEvent.key values.
  */
-export function keyNameVals(keyName: ?string): ?string {
+export function keyNameVals(keyName: ?string): string {
+  if (!keyName) {
+    return 'Unidentified';
+  }
+
   const cases = {
     left: 'ArrowLeft',
     up: 'ArrowUp',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,14 +30,38 @@ export function isInput(element: HTMLElement): boolean {
  * Maps [keycodes](https://www.npmjs.com/package/keycodes) key names to KeyboardEvent.key values.
  */
 export function keyValues(keyName: string): string {
-  const cases = {
+  const keys = {
+    ctrl: 'Control',
+    control: 'Control',
+    alt: 'Alt',
+    option: 'Option',
+    shift: 'Shift',
+    windows: 'Meta',
+    command: 'Meta',
+    esc: 'Escape',
+    escape: 'Escape',
+    backspace: 'Backspace',
+    tab: 'Tab',
+    enter: 'Enter',
+    'return': 'Enter',
+    space: ' ',
+    pause: 'Pause',
+    insert: 'Insert',
+    'delete': 'Delete',
+    home: 'Home',
+    end: 'End',
+    pageup: 'PageUp',
+    pagedown: 'PageDown',
     left: 'ArrowLeft',
     up: 'ArrowUp',
     right: 'ArrowRight',
     down: 'ArrowDown',
+    capslock: 'CapsLock',
+    numlock: 'NumLock',
+    scrolllock: 'ScrollLock',
   };
 
-  return cases[keyName] || keyName;
+  return keys[keyName] || keyName;
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,3 +13,17 @@ export function isInput(element: HTMLElement): boolean {
 
   return tagName === 'INPUT' || tagName === 'TEXTAREA';
 }
+
+/**
+ * Maps [keycodes](https://www.npmjs.com/package/keycodes) key names to KeyboardEvent.key values.
+ */
+export function keyNameVals(keyName: string): string {
+  const cases = {
+    left: 'ArrowLeft',
+    up: 'ArrowUp',
+    right: 'ArrowRight',
+    down: 'ArrowDown',
+  };
+
+  return cases[keyName] || keyName;
+}

--- a/test/components/key-handler.test.js
+++ b/test/components/key-handler.test.js
@@ -90,7 +90,7 @@ describe('KeyHandler', () => {
 
   it('prioritizes key value over code/name', () => {
     const handler = sinon.spy();
-    mount(<KeyHandler keyCode={M} keyValue={ARROW_LEFT} onKeyHandle={handler} />);
+    mount(<KeyHandler keyCode={M} keyName="m" keyValue={ARROW_LEFT} onKeyHandle={handler} />);
 
     triggerKeyEvent(KEYUP, S, ARROW_LEFT);
 

--- a/test/components/key-handler.test.js
+++ b/test/components/key-handler.test.js
@@ -7,11 +7,22 @@ import KeyHandler, {KEYUP, KEYDOWN} from 'components/key-handler';
 
 const M = 77;
 const S = 83;
+const ARROW_LEFT = 'ArrowLeft';
+const ARROW_RIGHT = 'ArrowRight';
 
 describe('KeyHandler', () => {
   it('renders nothing', () => {
     const el = render(<KeyHandler />);
     expect(el).to.be.blank();
+  });
+
+  it('handles key up events when key value match', () => {
+    const handler = sinon.spy();
+    mount(<KeyHandler keyValue={ARROW_LEFT} onKeyHandle={handler} />);
+
+    triggerKeyEvent(KEYUP, undefined, ARROW_LEFT);
+
+    expect(handler.calledOnce).to.equal(true);
   });
 
   it('handles key up events when key code match', () => {
@@ -30,6 +41,15 @@ describe('KeyHandler', () => {
     triggerKeyEvent(KEYUP, M);
 
     expect(handler.calledOnce).to.equal(true);
+  });
+
+  it('ignores key up events when no key value match', () => {
+    const handler = sinon.spy();
+    mount(<KeyHandler keyValue={ARROW_LEFT} onKeyHandle={handler} />);
+
+    triggerKeyEvent(KEYUP, undefined, ARROW_RIGHT);
+
+    expect(handler.calledOnce).to.equal(false);
   });
 
   it('ignores key up events when no key code match', () => {
@@ -67,9 +87,18 @@ describe('KeyHandler', () => {
 
     expect(handler.calledOnce).to.equal(true);
   });
+
+  it('prioritizes key value over code/name', () => {
+    const handler = sinon.spy();
+    mount(<KeyHandler keyCode={M} keyValue={ARROW_LEFT} onKeyHandle={handler} />);
+
+    triggerKeyEvent(KEYUP, S, ARROW_LEFT);
+
+    expect(handler.calledOnce).to.equal(true);
+  });
 });
 
-function triggerKeyEvent(eventName, keyCode) {
-  const event = new window.KeyboardEvent(eventName, { keyCode });
+function triggerKeyEvent(eventName, keyCode, keyValue = undefined) {
+  const event = new window.KeyboardEvent(eventName, { keyCode, key: keyValue });
   document.dispatchEvent(event);
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {isInput} from 'utils';
+import {isInput, keyNameVals} from 'utils';
 
 describe('isInput', () => {
   it('returns true if the element is an input', () => {
@@ -17,5 +17,14 @@ describe('isInput', () => {
 
   it('returns false if the element is not an input or textarea', () => {
     expect(isInput({ tagName: 'A' })).to.be.false;
+  });
+});
+
+describe('keyNameVals', () => {
+  it('returns the key value of the given key name', () => {
+    expect(keyNameVals('left')).to.be.equal('ArrowLeft');
+    expect(keyNameVals('up')).to.be.equal('ArrowUp');
+    expect(keyNameVals('right')).to.be.equal('ArrowRight');
+    expect(keyNameVals('down')).to.be.equal('ArrowDown');
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {isInput, keyNameVals} from 'utils';
+import {isInput, keyValues} from 'utils';
 
 describe('isInput', () => {
   it('returns true if the element is an input', () => {
@@ -20,12 +20,16 @@ describe('isInput', () => {
   });
 });
 
-describe('keyNameVals', () => {
+describe('keyValues', () => {
   it('returns the key value of the given key name', () => {
-    expect(keyNameVals('left')).to.be.equal('ArrowLeft');
-    expect(keyNameVals('up')).to.be.equal('ArrowUp');
-    expect(keyNameVals('right')).to.be.equal('ArrowRight');
-    expect(keyNameVals('down')).to.be.equal('ArrowDown');
-    expect(keyNameVals('numlock')).to.be.equal('numlock');
+    expect(keyValues('left')).to.be.equal('ArrowLeft');
+    expect(keyValues('up')).to.be.equal('ArrowUp');
+    expect(keyValues('right')).to.be.equal('ArrowRight');
+    expect(keyValues('down')).to.be.equal('ArrowDown');
+
+  });
+
+  it('falls back to the key name if there is no key value for given key name', () => {
+    expect(keyValues('numlock')).to.be.equal('numlock');
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -22,14 +22,37 @@ describe('isInput', () => {
 
 describe('keyValues', () => {
   it('returns the key value of the given key name', () => {
+    expect(keyValues('ctrl')).to.be.equal('Control');
+    expect(keyValues('control')).to.be.equal('Control');
+    expect(keyValues('alt')).to.be.equal('Alt');
+    expect(keyValues('option')).to.be.equal('Option');
+    expect(keyValues('shift')).to.be.equal('Shift');
+    expect(keyValues('windows')).to.be.equal('Meta');
+    expect(keyValues('command')).to.be.equal('Meta');
+    expect(keyValues('esc')).to.be.equal('Escape');
+    expect(keyValues('escape')).to.be.equal('Escape');
+    expect(keyValues('backspace')).to.be.equal('Backspace');
+    expect(keyValues('tab')).to.be.equal('Tab');
+    expect(keyValues('enter')).to.be.equal('Enter');
+    expect(keyValues('return')).to.be.equal('Enter');
+    expect(keyValues('space')).to.be.equal(' ');
+    expect(keyValues('pause')).to.be.equal('Pause');
+    expect(keyValues('insert')).to.be.equal('Insert');
+    expect(keyValues('delete')).to.be.equal('Delete');
+    expect(keyValues('home')).to.be.equal('Home');
+    expect(keyValues('end')).to.be.equal('End');
+    expect(keyValues('pageup')).to.be.equal('PageUp');
+    expect(keyValues('pagedown')).to.be.equal('PageDown');
     expect(keyValues('left')).to.be.equal('ArrowLeft');
     expect(keyValues('up')).to.be.equal('ArrowUp');
     expect(keyValues('right')).to.be.equal('ArrowRight');
     expect(keyValues('down')).to.be.equal('ArrowDown');
-
+    expect(keyValues('capslock')).to.be.equal('CapsLock');
+    expect(keyValues('numlock')).to.be.equal('NumLock');
+    expect(keyValues('scrolllock')).to.be.equal('ScrollLock');
   });
 
   it('falls back to the key name if there is no key value for given key name', () => {
-    expect(keyValues('numlock')).to.be.equal('numlock');
+    expect(keyValues('break')).to.be.equal('break');
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -26,5 +26,6 @@ describe('keyNameVals', () => {
     expect(keyNameVals('up')).to.be.equal('ArrowUp');
     expect(keyNameVals('right')).to.be.equal('ArrowRight');
     expect(keyNameVals('down')).to.be.equal('ArrowDown');
+    expect(keyNameVals('numlock')).to.be.equal('numlock');
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {isInput, keyValues} from 'utils';
+import {isInput, keyValues, keyValueFromCode, matchesKeyboardEvent} from 'utils';
 
 describe('isInput', () => {
   it('returns true if the element is an input', () => {
@@ -54,5 +54,52 @@ describe('keyValues', () => {
 
   it('falls back to the key name if there is no key value for given key name', () => {
     expect(keyValues('break')).to.be.equal('break');
+  });
+});
+
+describe('keyValueFromCode', () => {
+  it('returns the key value of a given key code', () => {
+    expect(keyValueFromCode(13)).to.be.equal('Enter');
+    expect(keyValueFromCode(32)).to.be.equal(' ');
+  });
+});
+
+describe('matchesKeyboardEvent', () => {
+  describe('matches KeyboardEvent.key against', () => {
+    const arrowUpValueEvent = new window.KeyboardEvent('keyup', {key: 'ArrowUp'});
+
+    it('keyValue Props property', () => {
+      expect(matchesKeyboardEvent(arrowUpValueEvent, {keyValue: 'ArrowUp'})).to.be.true;
+      expect(matchesKeyboardEvent(arrowUpValueEvent, {keyValue: 'ArrowDown'})).to.be.false;
+    });
+
+    it('keyCode Props property', () => {
+      expect(matchesKeyboardEvent(arrowUpValueEvent, {keyCode: 38})).to.be.true;
+      expect(matchesKeyboardEvent(arrowUpValueEvent, {keyCode: 40})).to.be.false;
+    });
+
+    it('keyName Props property', () => {
+      expect(matchesKeyboardEvent(arrowUpValueEvent, {keyName: 'up'})).to.be.true;
+      expect(matchesKeyboardEvent(arrowUpValueEvent, {keyName: 'down'})).to.be.false;
+    });
+  });
+
+  describe('matches KeyboardEvent.keyCode against', () => {
+    const arrowUpCodeEvent = new window.KeyboardEvent('keyup', {keyCode: 38});
+
+    it('keyValue Props property', () => {
+      expect(matchesKeyboardEvent(arrowUpCodeEvent, {keyValue: 'ArrowUp'})).to.be.true;
+      expect(matchesKeyboardEvent(arrowUpCodeEvent, {keyValue: 'ArrowDown'})).to.be.false;
+    });
+
+    it('keyCode Props property', () => {
+      expect(matchesKeyboardEvent(arrowUpCodeEvent, {keyCode: 38})).to.be.true;
+      expect(matchesKeyboardEvent(arrowUpCodeEvent, {keyCode: 40})).to.be.false;
+    });
+
+    it('keyName Props property', () => {
+      expect(matchesKeyboardEvent(arrowUpCodeEvent, {keyName: 'up'})).to.be.true;
+      expect(matchesKeyboardEvent(arrowUpCodeEvent, {keyName: 'down'})).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
As discussed at #7 

[`KeyboardEvent.keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated, also MDN recommends to avoid it for new projects in favor of [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).

This PR is a result of following this recommendations without dropping the support for `keyCode` since not every browser has implemented the new standard yet.

The usage of `keyValue` instead of `keyId` as discussed at #7 is to match an [ubiquitous terminology with current standards](https://www.w3.org/TR/uievents/#glossary-key-value).

Now, despite letter case, the arrow keys values are the only difference I notice from [`keycodes`](https://www.npmjs.com/package/keycodes) naming to actual `key` values so `keyNameVals` might seams dummy, but it allows to map any another differences.

Hope it helps!
Cheers