### PR TITLE
Improve documentation and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ React component to handle keyboard events (such as keyup, keydown & keypress).
   1. [Component](#component)
   1. [Form key handling](#form-key-handling)
 1. [Key event names](#key-event-names)
+1. [`keyValue`, `keyCode`, `keyName`](#keyvalue-keycode-keyname)
 1. [Development](#development)
 1. [Contributing](#contributing)
 1. [License](#license)
@@ -124,8 +125,8 @@ The prop types of the `KeyHandler` component are:
 | Name         | Type     | Required   | Default   |                                                   |
 | ------------ | -------- | ---------- | --------- | ------------------------------------------------- |
 | keyEventName | string   | yes        | `'keyup'` | `'keydown'`, `'keypress'` or `'keyup'`.           |
-| keyValue     | string   | yes __\*__ |           | Any given [keyboard key]                          |
-| keyCode      | number   | yes __\*__ |           | Any given [keyboard code]                         |
+| keyValue     | string   | yes __\*__ |           | Any given [KeyboardEvent.keyCode]                 |
+| keyCode      | number   | yes __\*__ |           | Any given [KeyboardEvent.key]                    |
 | keyName      | string   | yes __\*__ |           | Any given character                               |
 | onKeyHandle  | function | yes        |           | Function that is called when they key is handled. |
 
@@ -144,6 +145,31 @@ React does a fine job supporting these already via [keyboard events](https://fac
 ## Key event names
 
 TODO: explain the differences between the different key events.
+
+## `keyValue`, `keyCode`, `keyName`
+
+Originally this library only supported [KeyboardEvent.keyCode], which is what is currently is most supported by browsers these days,
+but this feature has been removed from the Web standards in favour of [KeyboardEvent.key].
+
+We can't use the reserved [key] property, so we picked `keyValue`.
+
+`keyName` was an in-between solution powered by [keycodes] to support human readable strings,
+this property will be deprecated in future versions.
+
+__Browser support:__
+
+Internally we normalize deprecated HTML5 `keyValue` values and translate from legacy `keyCode` values,
+similar to how React does this for their `SyntheticKeyboardEvent`.
+
+Meaning you can safely use any property in any modern browser.
+
+__More information:__
+
+Read the [W3C Working Draft].
+
+__TL;DR__:
+
+Stick to standards, use `keyValue` over `keyCode`, avoid using `keyName`.
 
 ## Development
 
@@ -204,5 +230,8 @@ to the [Contributor Covenant](http://contributor-covenant.org/) code of conduct.
                 ||     ||
 ```
 
-[keyboard key]: https://www.w3.org/TR/DOM-Level-3-Events-key/
-[keyboard code]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+[W3C Working Draft]: https://www.w3.org/TR/DOM-Level-3-Events-key/
+[KeyboardEvent.key]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+[KeyboardEvent.keyCode]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+[keycodes]: https://www.npmjs.com/package/keycodes
+[key]: https://facebook.github.io/react/docs/create-fragment.html

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ React component to handle key events.
   1. [`keyToggleHandler` decorator](#keytogglehandler-decorator)
   1. [`KeyHandler` component](#keyhandler-component)
   1. [Form key handling](#form-key-handling)
-  1. [Demos](#demos)
 1. [Development](#development)
 1. [Contributing](#contributing)
 1. [License](#license)
@@ -139,17 +138,11 @@ You should either pass a `keyValue`, a `keyCode` or a `keyName`, not both.
 
 ### Form key handling
 
-This library does not handle any keys coming from an `<input />` or `<textarea />` element.
+This library does not handle key events for form elements such as `<input />` and `<textarea />`.
 
-We recommend you to use react's built in [form events](https://facebook.github.io/react/docs/events.html#form-events)
-for these.
+React does a fine job supporting these already via [keyboard events](https://facebook.github.io/react/docs/events.html#keyboard-events).
 
-If you disagree and feel very strong about this, feel free to open an issue with
-your reasoning and we will consider adding this functionality.
-
-### Demos
-
-For more examples have a look at `demo/components/demos/`.
+[Examples](demo/components/examples/input/).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ React component to handle key events.
 
 1. [Installation](#installation)
 1. [Usage](#usage)
-  1. [`keyHandler` decorator](#keyhandler-decorator)
-  1. [`keyToggleHandler` decorator](#keytogglehandler-decorator)
-  1. [`KeyHandler` component](#keyhandler-component)
+  1. [Decorators](#decorators)
+  1. [Component](#component)
   1. [Form key handling](#form-key-handling)
-  1. [Key even names](#key-event-names)
+  1. [Key event names](#key-event-names)
 1. [Development](#development)
 1. [Contributing](#contributing)
 1. [License](#license)
@@ -25,14 +24,21 @@ $ npm install react-key-handler --save
 
 ## Usage
 
-`react-key-handler` comes in 2 flavors, a component and decorators.
+`react-key-handler` comes in two flavours, a component and decorators.
 
-Unless you want absolute flexibility we highly recommend you to use one of the decorators.
+Unless you want absolute flexibility we recommend you to use one of the decorators.
 
-### `keyHandler` decorator
+### Decorators
 
-The decorator will decorate the given component with a `keyValue`, `keyCode` and `keyName`
-property.
+This library includes two different decorators:
+
+| Decorator          | Handles     |
+| ------------------ | ----------- |
+| `keyHandler`       | Key changes |
+| `keyToggleHandler` | Key toggles |
+
+Both decorators have the same API and both will decorate the given component with
+a `keyValue`, `keyCode` and `keyName` property.
 
 ```jsx
 import React from 'react';
@@ -56,30 +62,20 @@ function DecoratorDemo({keyCode}) {
 export default keyHandler({keyCode: S_KEY_CODE})(DecoratorDemo);
 ```
 
-The prop types of the `keyHandler` decorator are:
+The prop types of the `KeyHandler` component are:
 
-```js
-type Props = {
-  keyValue: ?string,
-  keyCode: ?number,
-  keyEventName: ?string,
-  keyName: ?string,
-}
-```
+| Name         | Type     | Required   | Default   |                                                   |
+| ------------ | -------- | ---------- | --------- | ------------------------------------------------- |
+| keyEventName | string   | yes        | `'keyup'` | `'keydown'`, `'keypress'` or `'keyup'`.           |
+| keyValue     | string   | yes __\*__ |           | Any given [keyboard key]                          |
+| keyCode      | number   | yes __\*__ |           | Any given [keyboard code]                         |
+| keyName      | string   | yes __\*__ |           | Any given character                               |
 
-* `keyValue` can be any given [W3C keyboard key value](https://www.w3.org/TR/DOM-Level-3-Events-key/)
-* `keyCode` can be any given [keyboard code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
-* `keyEventName` will default to `'keyup'`
-* `keyName` can be any given character
+__\*__ You should pass only one of these three props: `keyValue`, `keyCode` or `keyName`.
 
-You should either pass a `keyValue`, a `keyCode` or a `keyName`, not both.
+[Examples](demo/components/examples/decorators/)
 
-### `keyToggleHandler` decorator
-
-This decorator has the exact same API as the `keyHandler` decorator and should be used
-for when you're looking to toggle a key.
-
-### `KeyHandler` component
+### Component
 
 ```jsx
 import React from 'react';

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/react-key-handler.svg)](https://www.npmjs.com/package/react-key-handler) [![License](https://img.shields.io/npm/l/react-key-handler.svg)](https://www.npmjs.com/package/react-key-handler) [![Build Status](https://travis-ci.org/ayrton/react-key-handler.svg?branch=master)](https://travis-ci.org/ayrton/react-key-handler)
 
-React component to handle key events.
+React component to handle keyboard events (such as keyup, keydown & keypress).
 
 ## Table of Contents
 
@@ -31,8 +31,8 @@ You can use `react-key-handler` in two flavours:
 
 Unless you want absolute flexibility we recommend you to use one of the decorators.
 
-NOTE: Both decorators use the `KeyHandler` component internally, for a full understand
-you should check out [the source code](lib/components/key-handler.js).
+Both decorators use the `KeyHandler` component internally, for a full understanding
+you can check out [the implementation](lib/components/key-handler.js).
 
 ### Decorators
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The prop types of the `KeyHandler` component are:
 | keyValue     | string   | yes __\*__ |           | Any given [keyboard key]                          |
 | keyCode      | number   | yes __\*__ |           | Any given [keyboard code]                         |
 | keyName      | string   | yes __\*__ |           | Any given character                               |
-| onKeyHandler | function | yes        |           | Function that is called when they key is handled. |
+| onKeyHandle  | function | yes        |           | Function that is called when they key is handled. |
 
 __\*__ You should pass only one of these three props: `keyValue`, `keyCode` or `keyName`.
 

--- a/README.md
+++ b/README.md
@@ -136,13 +136,15 @@ type Props = {
 
 You should either pass a `keyValue`, a `keyCode` or a `keyName`, not both.
 
+[Example](demo/components/examples/component/index.js)
+
 ### Form key handling
 
 This library does not handle key events for form elements such as `<input />` and `<textarea />`.
 
 React does a fine job supporting these already via [keyboard events](https://facebook.github.io/react/docs/events.html#keyboard-events).
 
-[Examples](demo/components/examples/input/).
+[Examples](demo/components/examples/input/)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ React component to handle key events.
   1. [`keyToggleHandler` decorator](#keytogglehandler-decorator)
   1. [`KeyHandler` component](#keyhandler-component)
   1. [Form key handling](#form-key-handling)
+  1. [Key even names](#key-event-names)
 1. [Development](#development)
 1. [Contributing](#contributing)
 1. [License](#license)
@@ -118,23 +119,15 @@ export default React.createClass({
 
 The prop types of the `KeyHandler` component are:
 
-```js
-type Props = {
-  keyValue: ?string,
-  keyCode: ?number,
-  keyEventName: string,
-  keyName: ?string,
-  onKeyHandle: Function,
-};
-```
+| Name         | Type     | Required   | Default   |                                                   |
+| ------------ | -------- | ---------- | --------- | ------------------------------------------------- |
+| keyEventName | string   | yes        | `'keyup'` | `'keydown'`, `'keypress'` or `'keyup'`.           |
+| keyValue     | string   | yes __\*__ |           | Any given [keyboard key]                          |
+| keyCode      | number   | yes __\*__ |           | Any given [keyboard code]                         |
+| keyName      | string   | yes __\*__ |           | Any given character                               |
+| onKeyHandler | function | yes        |           | Function that is called when they key is handled. |
 
-* `keyValue` can be any given [W3C keyboard key value](https://www.w3.org/TR/DOM-Level-3-Events-key/)
-* `keyCode` can be any given [keyboard code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
-* `keyEventName` will default to `'keyup'`
-* `keyName` can be any given character
-* `onKeyHandle` is the function that is being called when key code is handled
-
-You should either pass a `keyValue`, a `keyCode` or a `keyName`, not both.
+__\*__ You should pass only one of these three props: `keyValue`, `keyCode` or `keyName`.
 
 [Example](demo/components/examples/component/index.js)
 
@@ -145,6 +138,10 @@ This library does not handle key events for form elements such as `<input />` an
 React does a fine job supporting these already via [keyboard events](https://facebook.github.io/react/docs/events.html#keyboard-events).
 
 [Examples](demo/components/examples/input/)
+
+### Key event names
+
+TODO: explain the differences between the different key events.
 
 ## Development
 
@@ -204,3 +201,6 @@ to the [Contributor Covenant](http://contributor-covenant.org/) code of conduct.
                 ||----w |
                 ||     ||
 ```
+
+[keyboard key]: https://www.w3.org/TR/DOM-Level-3-Events-key/
+[keyboard code]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ React component to handle key events.
   1. [Decorators](#decorators)
   1. [Component](#component)
   1. [Form key handling](#form-key-handling)
-  1. [Key event names](#key-event-names)
+1. [Key event names](#key-event-names)
 1. [Development](#development)
 1. [Contributing](#contributing)
 1. [License](#license)
@@ -24,9 +24,15 @@ $ npm install react-key-handler --save
 
 ## Usage
 
-`react-key-handler` comes in two flavours, a component and decorators.
+You can use `react-key-handler` in two flavours:
+
+- decorator
+- component
 
 Unless you want absolute flexibility we recommend you to use one of the decorators.
+
+NOTE: Both decorators use the `KeyHandler` component internally, for a full understand
+you should check out [the source code](lib/components/key-handler.js).
 
 ### Decorators
 
@@ -135,7 +141,7 @@ React does a fine job supporting these already via [keyboard events](https://fac
 
 [Examples](demo/components/examples/input/)
 
-### Key event names
+## Key event names
 
 TODO: explain the differences between the different key events.
 

--- a/demo/components/app.js
+++ b/demo/components/app.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import InputElement from './examples/input/default';
 import InputElementKeypress from './examples/input/keypress';
-import KeyHandlerComponent from './demos/key-handler-component';
+import KeyHandlerComponent from './examples/component';
 import KeyHandlerDecorator from './demos/key-handler-decorator';
 import KeyToggleHandlerDecorator from './demos/key-toggle-handler-decorator';
 

--- a/demo/components/app.js
+++ b/demo/components/app.js
@@ -5,8 +5,8 @@ import React from 'react';
 import InputElement from './examples/input/default';
 import InputElementKeypress from './examples/input/keypress';
 import KeyHandlerComponent from './examples/component';
-import KeyHandlerDecorator from './demos/key-handler-decorator';
-import KeyToggleHandlerDecorator from './demos/key-toggle-handler-decorator';
+import KeyHandlerDecorator from './examples/decorators/key-handler';
+import KeyToggleHandlerDecorator from './examples/decorators/key-toggle-handler';
 
 /**
  * App component.

--- a/demo/components/app.js
+++ b/demo/components/app.js
@@ -2,7 +2,8 @@
 
 import React from 'react';
 
-import InputElement from './demos/input-element';
+import InputElement from './examples/input/default';
+import InputElementKeypress from './examples/input/keypress';
 import KeyHandlerComponent from './demos/key-handler-component';
 import KeyHandlerDecorator from './demos/key-handler-decorator';
 import KeyToggleHandlerDecorator from './demos/key-toggle-handler-decorator';
@@ -24,6 +25,7 @@ export default function App(): React$Element {
       <KeyToggleHandlerDecorator/>
       <KeyHandlerComponent />
       <InputElement />
+      <InputElementKeypress />
     </div>
   );
 }

--- a/demo/components/examples/component/index.js
+++ b/demo/components/examples/component/index.js
@@ -2,13 +2,13 @@
 
 import React from 'react';
 
-import KeyHandler from '../../../lib';
+import KeyHandler from '../../../../lib';
 
 type State = {
   showMenu: boolean,
 };
 
-export default class Demo extends React.Component {
+export default class Component extends React.Component {
   state: State = { showMenu: false };
 
   toggleMenu: (event: KeyboardEvent) => void;
@@ -26,7 +26,7 @@ export default class Demo extends React.Component {
       <div>
         <KeyHandler keyName="s" onKeyHandle={this.toggleMenu} />
 
-        <h2>Component example</h2>
+        <h2>Component example:</h2>
 
         <p>Press <code>s</code> to <strong>toggle</strong> the menu.</p>
 

--- a/demo/components/examples/decorators/key-handler.js
+++ b/demo/components/examples/decorators/key-handler.js
@@ -2,18 +2,19 @@
 
 import React from 'react';
 
-import {keyToggleHandler} from '../../../lib';
+import {keyHandler} from '../../../../lib';
 
 type Props = {
   keyName: ?string,
 };
 
+
 function Demo({keyName}: Props): React$Element {
   return (
     <div>
-      <h2>Toggle Decorator example:</h2>
+      <h2>Decorator example:</h2>
 
-      <p>Press <code>s</code> to <strong>toggle</strong> the menu.</p>
+      <p>Press <code>s</code> to <strong>open</strong> the menu.</p>
 
       {keyName === 's' &&
         <ol>
@@ -25,4 +26,4 @@ function Demo({keyName}: Props): React$Element {
   );
 }
 
-export default keyToggleHandler({keyName: 's'})(Demo);
+export default keyHandler({keyName: 's'})(Demo);

--- a/demo/components/examples/decorators/key-toggle-handler.js
+++ b/demo/components/examples/decorators/key-toggle-handler.js
@@ -2,19 +2,18 @@
 
 import React from 'react';
 
-import {keyHandler} from '../../../lib';
+import {keyToggleHandler} from '../../../../lib';
 
 type Props = {
   keyName: ?string,
 };
 
-
 function Demo({keyName}: Props): React$Element {
   return (
     <div>
-      <h2>Decorator example:</h2>
+      <h2>Toggle Decorator example:</h2>
 
-      <p>Press <code>s</code> to <strong>open</strong> the menu.</p>
+      <p>Press <code>s</code> to <strong>toggle</strong> the menu.</p>
 
       {keyName === 's' &&
         <ol>
@@ -26,4 +25,4 @@ function Demo({keyName}: Props): React$Element {
   );
 }
 
-export default keyHandler({keyName: 's'})(Demo);
+export default keyToggleHandler({keyName: 's'})(Demo);

--- a/demo/components/examples/input/default.js
+++ b/demo/components/examples/input/default.js
@@ -2,25 +2,25 @@
 
 import React from 'react';
 
-import {keyToggleHandler} from '../../../lib';
+import {keyToggleHandler} from '../../../../lib';
 
 type Props = {
-  keyName: ?string,
+  keyValue: ?string,
 };
 
-function Demo({keyName}: Props): React$Element {
+function Default({keyValue}: Props): React$Element {
   return (
     <div>
       <h2>Input example:</h2>
 
       <p>
         Press <code>s</code> in the following form component and see that the key
-        handle will be ignored.
+        handle will be ignored by default.
       </p>
 
       <input />
 
-      {keyName === 's' &&
+      {keyValue === 's' &&
         <ol>
           <li>hello</li>
           <li>world</li>
@@ -30,4 +30,4 @@ function Demo({keyName}: Props): React$Element {
   );
 }
 
-export default keyToggleHandler({keyName: 's'})(Demo);
+export default keyToggleHandler({keyValue: 's'})(Default);

--- a/demo/components/examples/input/keypress.js
+++ b/demo/components/examples/input/keypress.js
@@ -1,0 +1,46 @@
+/* @flow */
+
+import React from 'react';
+
+type State = {
+  keyValue: ?string,
+};
+
+export default class Keypress extends React.Component {
+  state: State = { keyValue: null };
+
+  handleKeyPress: (event: SyntheticKeyboardEvent) => void;
+
+  constructor() {
+    super();
+
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+  }
+
+  render(): React$Element {
+    return (
+      <div>
+        <h2>Input onKeyPress example:</h2>
+
+        <p>
+          Press <code>s</code> in the following form component to toggle the menu.
+        </p>
+
+        <input onKeyPress={this.handleKeyPress} />
+
+        {this.state.keyValue === 's' &&
+          <ol>
+            <li>hello</li>
+            <li>world</li>
+          </ol>
+        }
+      </div>
+    );
+  }
+
+  handleKeyPress({key}: SyntheticKeyboardEvent) {
+    const keyValue = this.state.keyValue === key ? null : key;
+
+    this.setState({ keyValue });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-key-handler",
   "version": "0.1.0",
-  "description": "React component to handle key events",
+  "description": "React component to handle keyboard events",
   "homepage": "https://github.com/ayrton/react-key-handler",
   "author": {
     "name": "Ayrton De Craene",


### PR DESCRIPTION
The documentation and demos aren't as good as they could be, these things currently come to mind:

__README:__

- [x] Split up examples by type: decorator, component, form components
- [x] Include link to examples in README section per type
- [x] Explain the difference between `keyValue`, `keyCode` & `keyName`
- [x] Explain what the possible options are for `keyEventName`
- [x] ~~Explain when to use which `keyEventName`~~ (different PR)

__DEMOS:__

- [x] Split up per type
- [x] ~~Don't use relative path to include the library, do:~~ (different PR)

```js
import ReactKeyHandler from 'react-key-handler';
```