### PR TITLE
eslint-plugin-flow-vars is deprecated

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,11 @@
     "mocha": true,
     "node": true
   },
-  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:flowtype/recommended",
+    "plugin:react/recommended"
+  ],
   "parserOptions": {
     "ecmaFeatures": {
       "experimentalObjectRestSpread": true,
@@ -25,7 +29,7 @@
     "sourceType": "module"
   },
   "plugins": [
-    "react",
-    "flow-vars"
+    "flowtype",
+    "react"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "enzyme": "^2.2.0",
     "eslint": "^3.5.0",
     "eslint-loader": "^1.5.0",
-    "eslint-plugin-flow-vars": "^0.5.0",
+    "eslint-plugin-flowtype": "^2.17.1",
     "eslint-plugin-react": "^6.2.0",
     "flow-bin": "^0.32.0",
     "jsdom": "^9.4.1",


### PR DESCRIPTION
[eslint-plugin-flow-vars](https://github.com/zertosh/eslint-plugin-flow-vars) is deprecated in favour of [eslint-plugin-flowtype](https://github.com/gajus/eslint-plugin-flowtype). This PR migrates to the new eslint plugin.
