### PR TITLE
Adds new `handledKeys` prop to handle more than one key

### DIFF
--- a/lib/key-handler.js
+++ b/lib/key-handler.js
@@ -16,6 +16,7 @@ export default class KeyHandler extends React.Component {
     keyCode?: number,
     keyEventName: KEYDOWN | KEYPRESS | KEYUP,
     onKeyHandle?: (event: KeyboardEvent) => void,
+    handledKeys?: Array<HandledKey>,
   };
 
   static propTypes = {
@@ -23,6 +24,13 @@ export default class KeyHandler extends React.Component {
     keyCode: React.PropTypes.number,
     keyEventName: React.PropTypes.oneOf([KEYDOWN, KEYPRESS, KEYUP]),
     onKeyHandle: React.PropTypes.func,
+    handledKeys: React.PropTypes.arrayOf(
+      React.PropTypes.shape({
+        keyValue: React.PropTypes.string,
+        keyCode: React.PropTypes.number,
+        allowInputTarget: React.PropTypes.bool,
+      })
+    ),
   };
 
   static defaultProps = {
@@ -36,13 +44,21 @@ export default class KeyHandler extends React.Component {
   constructor(props) {
     super(props);
 
+    this.handleKey = this.handleKey.bind(this);
+
     /* eslint-disable no-console */
 
-    if (!props.keyValue && !props.keyCode) {
-      console.error('Warning: Failed propType: Missing prop `keyValue` or `keyCode` for `KeyHandler`.');
+    if (!(props.keyValue || props.keyCode) && !props.handledKeys) {
+      console.error('Warning: Failed propType: Missing prop `handledKeys` or `keyValue` or `keyCode` for `KeyHandler`.');
     }
 
     /* eslint-enable */
+  }
+
+  handledKeys() {
+    /* normalize legacy props into new handledKeys array */
+    const { handledKeys, keyValue, keyCode } = this.props;
+    return handledKeys ? handledKeys : [{keyValue, keyCode}];
   }
 
   componentDidMount(): void {
@@ -62,20 +78,18 @@ export default class KeyHandler extends React.Component {
   }
 
   handleKey = (event: KeyboardEvent): void => {
-    const {keyValue, keyCode, onKeyHandle} = this.props;
+    const {onKeyHandle} = this.props;
+    const matchesEvent = matchesKeyboardEvent.bind(null, event);
+    const handledKey = this.handledKeys().find(key => matchesEvent(key));
 
-    if (!onKeyHandle) {
+    if (!onKeyHandle || !handledKey) {
       return;
     }
 
     const {target} = event;
 
     if (target instanceof window.HTMLElement && isInput(target)) {
-      return;
-    }
-
-    if (!matchesKeyboardEvent(event, {keyValue, keyCode})) {
-      return;
+      if (!handledKey.allowInputTarget) return;
     }
 
     onKeyHandle(event);
@@ -90,6 +104,8 @@ type DecoratorProps = {
   keyValue?: string,
   keyCode?: number,
   keyEventName?: string,
+  handledKeys?: Array<HandledKey>,
+  handleKey?: (event: KeyboardEvent) => void,
 }
 
 type State = {
@@ -97,13 +113,19 @@ type State = {
   keyCode: ?number,
 };
 
+type HandledKey = {
+  keyValue: ?string,
+  keyCode: ?number,
+  allowInputTarget?: bool,
+}
+
 /**
  * KeyHandler decorators.
  */
 
 function keyHandleDecorator(matcher?: typeof matchesKeyboardEvent): Function {
   return (props?: DecoratorProps): Function => {
-    const { keyValue, keyCode, keyEventName } = props || {};
+    const { keyValue, keyCode, keyEventName, handledKeys, handleKey } = props || {};
 
     return (Component) => (
       class KeyHandleDecorator extends React.Component {
@@ -112,7 +134,12 @@ function keyHandleDecorator(matcher?: typeof matchesKeyboardEvent): Function {
         render() {
           return (
             <div>
-              <KeyHandler keyValue={keyValue} keyCode={keyCode} keyEventName={keyEventName} onKeyHandle={this.handleKey} />
+              <KeyHandler
+                  keyValue={keyValue}
+                  keyCode={keyCode}
+                  keyEventName={keyEventName}
+                  handledKeys={handledKeys}
+                  onKeyHandle={handleKey || this.handleKey} />
               <Component {...this.props} {...this.state} />
             </div>
           );


### PR DESCRIPTION
Thanks for the nice library!

I saw in the issues a lot of requests to let this library handle multiple keys, so I took a stab at it. 

- The `KeyHandler` component takes a new prop called `handledKeys` which is basically an array of shape `keyValue`, `keyCode`, and a new prop I added called `allowInputTarget` which allows the event to pass even if it's target is an `input` (I have the use case to listen to 'Escape' key from inputs). 
- The `keyHandler` HOC also takes a new prop called `handleKey`, and if present, it passes that to `KeyHandler` component as the value of `onKeyHandle`, instead of it's own `this.handleKey`. This lets you take control and handle all the key events with your own function without using the `KeyHandler` component directly.

Assuming you had some component with following methods:
`````javascript
handleKeyEvent(e) {
  switch(e.key) {
    case 'Escape':
      return console.log('hit escape');

    case 'ArrowLeft':
      return console.log('navigated direction');
  }
}

get handledKeys() {
  return [
    { keyValue: 'Escape', allowInputTarget: true },
    { keyCode: 37 }
  ];
}
`````

You could use it like this:
`````javascript
<KeyHandler
  keyEventName={KEYDOWN}
  handledKeys={this.handledKeys}
  onKeyHandle={this.handleKeyEvent} />
`````
Should also work the same using as a HOC.

Let me know if this looks good to you and I can try adding some unit tests for this behavior.